### PR TITLE
convert Process::Status to an int in ruby 1.9

### DIFF
--- a/lib/ghostbuster.rb
+++ b/lib/ghostbuster.rb
@@ -31,7 +31,7 @@ class Ghostbuster
         end
       end
     end
-    exit(status)
+    exit(status.to_i)
   end
 
   def self.run(path)


### PR DESCRIPTION
I'm gettting errors under ruby 1.9.2:

```
Starting server |
GhostBuster
For ./test_things.coffee
  ✓ Home page text

1 success, 0 failure, 0 pending
Stopping server /
/Users/chris/.rvm/gems/ruby-1.9.2-p290/gems/ghostbuster-0.2.4/lib/ghostbuster.rb:34:in `exit': can't convert Process::Status into Integer (TypeError)
    from /Users/chris/.rvm/gems/ruby-1.9.2-p290/gems/ghostbuster-0.2.4/lib/ghostbuster.rb:34:in `run'
    from /Users/chris/.rvm/gems/ruby-1.9.2-p290/gems/ghostbuster-0.2.4/lib/ghostbuster/runner.rb:13:in `run'
    from /Users/chris/.rvm/gems/ruby-1.9.2-p290/gems/ghostbuster-0.2.4/bin/ghostbuster:4:in `<top (required)>'
    from /Users/chris/.rvm/gems/ruby-1.9.2-p290/bin/ghostbuster:19:in `load'
    from /Users/chris/.rvm/gems/ruby-1.9.2-p290/bin/ghostbuster:19:in `<main>'
```

The attached fix simply forces the status to be an integer.
