### PR TITLE
use querySelectorAll for assertCount

### DIFF
--- a/lib/ghostbuster.coffee
+++ b/lib/ghostbuster.coffee
@@ -144,7 +144,7 @@ class Body
         var evaluator = function() {
           try {
             var assertionCallback = #{assertionCallback.toString()};
-            var count = document.querySelector('#{selector}').length;
+            var count = document.querySelectorAll('#{selector}').length;
             var ret = assertionCallback(count);
             if (ret) {
               return true;


### PR DESCRIPTION
We were having problems with `assertCount` passing undefined to the callback, it seems that this was because it was only returning one element, and therefore the length property was returning undefined. Changing it to `querySelectorAll` seems to fix this.

I have tried running the tests but I'm not entirely sure what the output is supposed to look like!
