### PR TITLE
Propagate test failure message through to the final test report.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -36,7 +36,7 @@ namespace :test do
   task :non_working do
     print "non_working_ghost ... "
     Dir.chdir("test/non_working_ghost") do
-      matcher = [/0 success, 6 failure, 1 pending/, /Bad link traversal\s+Assert location failed: Excepted http:\/\/127\.0\.0\.1:4567\/not-correct, got http:\/\/127\.0\.0\.1:4567\//, /Form input not equal\s+Assert first for selector #out did not meet expectations/, /This test will explode!\s+I hate you!/, /This test has no succeed\s+This test took too long/]
+      matcher = [/0 success, 7 failure, 1 pending/, /Bad link traversal\s+Assert location failed: Excepted http:\/\/127\.0\.0\.1:4567\/not-correct, got http:\/\/127\.0\.0\.1:4567\//, /Form input not equal\s+Assert first for selector #out did not meet expectations/, /To an invalid URL\s+The request for http:\/\/127\.0\.0\.1:this-url-is-invalid failed/, /This test will explode!\s+I hate you!/, /This test has no succeed\s+This test took too long/]
       fork {
         ENV['BUNDLE_GEMFILE'] = File.expand_path("./Gemfile")
         `bundle install`

--- a/lib/ghostbuster.coffee
+++ b/lib/ghostbuster.coffee
@@ -40,8 +40,7 @@ class Test
   startTestTimer: ->
     test = this
     @testTimer ||= setTimeout (->
-      test.setLastError("This test took too long")
-      test.fail()
+      test.fail("This test took too long")
     ), @maxDuration
   runWithFunction: (fn, @callback) ->
     fn.call(this)
@@ -52,7 +51,7 @@ class Test
     @waitForAssertions ->
       test = this
       fatalCallback = ->
-        test.fail("The request for #{test.runner.normalizePath(path)} failed")
+        test.fail("The request for #{test.runner.normalizePath(path)} timed out")
       fatal = setTimeout fatalCallback, if opts.total then opts.total * 1000 else 1000
       loadedCallback = (status) ->
         clearTimeout fatal
@@ -65,7 +64,7 @@ class Test
             test.body = new Body(test)
             getCallback.call(test) if getCallback
           when 'fail'
-            test.fail()
+            test.fail("The request for #{test.runner.normalizePath(path)} failed")
       @page.open @runner.normalizePath(path), loadedCallback
   succeed: ->
     @waitForAssertions ->
@@ -290,7 +289,8 @@ class TestFile
             return
           processBefore 0, ->
             try
-              test.run (state) ->
+              test.run (state, msg) ->
+                testFile.lastErrors[test.name] = msg
                 testStates[test.name] = state
                 nextTest(count + 1)
             catch e

--- a/test/non_working_ghost/test_ghost.coffee
+++ b/test/non_working_ghost/test_ghost.coffee
@@ -17,4 +17,7 @@ phantom.test.add "Form input not equal", ->
 phantom.test.addPending "To a non existent page", ->
   @get '/404', ->
     @succeed()
-  
+
+phantom.test.add "To an invalid URL", ->
+  @get 'http://127.0.0.1:this-url-is-invalid', ->
+    @succeed()


### PR DESCRIPTION
The `msg` argument to the `Test::fail` method is currently unused, which means that failed page loads or timeouts result in cryptic "There was a problem" messages in the final test report.

This commit propagates the `msg` argument through to the final test report.
