### PR TITLE
Adding magic encoding comment to avoid crashes with Ruby 1.9 due to UTF8 strings.

### DIFF
--- a/lib/ghostbuster.rb
+++ b/lib/ghostbuster.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'fileutils'
 require 'digest/md5'
 


### PR DESCRIPTION
Adding magic encoding comment to avoid crashes with Ruby 1.9 due to UTF8 strings.
