### PR TITLE
Add start_wait config to set the sleep period while the start_command runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ To set the command for starting your server use:
 
     ghost.start_command "./start.sh"
 
+To set the timeout in seconds for the start_command to complete use:
+
+    ghost.start_wait = 2   # this is the default
+
 To set the command for stopping your server use:
 
     ghost.stop_command "./stop.sh"

--- a/lib/ghostbuster.rb
+++ b/lib/ghostbuster.rb
@@ -36,7 +36,7 @@ class Ghostbuster
         else
           sh @config.start_command
         end
-        sleep 2
+        sleep @config.start_wait
       end
       begin
         _, status = Process.waitpid2 fork { 

--- a/lib/ghostbuster/config.rb
+++ b/lib/ghostbuster/config.rb
@@ -12,6 +12,7 @@ class Ghostbuster
       @verbose = false
       @temp_dir = "/tmp"
       @start_command, @stop_command = "./start.sh", "./stop.sh"
+      @start_wait = 2
       if File.exist?(@config_file)
         instance_eval File.read(@config_file), @config_file, 1
       end


### PR DESCRIPTION
With the project I'm working on right now I don't need to start the server when the test runs. Rather than add new logic to bypass the server start, I figured it would be safer to just make the start wait configurable over the default of 2 seconds.

Projects with long-running async start scripts might find the ability to set a longer sleep useful too.
