### PR TITLE
Update phantom.js to version 1.5.0

### DIFF
--- a/bin/setup-ghostbuster
+++ b/bin/setup-ghostbuster
@@ -5,20 +5,20 @@ when /darwin/
   require 'fileutils'
   root = File.expand_path(File.join(ENV['HOME'], '.ghostbuster'))
   cache = File.expand_path(File.join(root, 'cache'))
-  unless File.exist?(File.join(root, 'version')) && File.read(File.join(root, 'version')) == '2'
+  unless File.exist?(File.join(root, 'version')) && File.read(File.join(root, 'version')) == '3'
     puts "Creating ghostbuster directory in your home"
     FileUtils.rm_rf(root)
     FileUtils.mkdir_p(root)
     FileUtils.mkdir_p(cache)
-    phantom_url = "http://phantomjs.googlecode.com/files/phantomjs-1.3.0-macosx-static-x86.zip"
+    phantom_url = "http://phantomjs.googlecode.com/files/phantomjs-1.5.0-macosx-static.zip"
     unless File.exist?(File.join(cache, File.basename(phantom_url)))
       Dir.chdir(cache) do
         puts "Downloading and installing phantom.js"
         system("curl #{phantom_url} -O") or raise("Unable to download from #{phantom_url}")
         system("unzip #{File.basename(phantom_url)}") or raise("Unable to unzip archive")
       end
-      File.exist?("#{cache}/phantomjs-1.3.0/bin/phantomjs") or raise("Unable to copy phantomjs from your disk image")
-      system("ln -s #{cache}/phantomjs-1.3.0/bin/phantomjs #{root}/phantomjs") or raise("Unable to copy phantomjs from your disk image")
+      File.exist?("#{cache}/phantomjs-1.5.0/bin/phantomjs") or raise("Unable to copy phantomjs from your disk image")
+      system("ln -s #{cache}/phantomjs-1.5.0/bin/phantomjs #{root}/phantomjs") or raise("Unable to copy phantomjs from your disk image")
       File.open("#{root}/version", 'w') {|f| f << '2' }
       puts "Done installing!"
     end

--- a/lib/ghostbuster.coffee
+++ b/lib/ghostbuster.coffee
@@ -435,7 +435,7 @@ class TestSuite
     @failure += failure
     @pending += pending
   run: ->
-    if phantom.version.major == 1 and phantom.version.minor == 3
+    if phantom.version.major == 1 and phantom.version.minor == 5
       @screenshots    = @args[0] == 'true'
       @screenshot_x   = @args[1]
       @screenshot_y   = @args[2]
@@ -464,7 +464,7 @@ class TestSuite
             console.log "Unable to load #{testFile}"
       runNextTest()
     else
-      console.log "Phantom version must be 1.3.x"
+      console.log "Phantom version must be 1.5.x"
       phantom.exit 1
 
 if phantom.args.length == 0


### PR DESCRIPTION
As described in issue #21, changes were made to install phantom.js version 1.5 while bootstrapping. All provided tests pass. (the non-working fail, of course ;))

However, I have no idea, how to update the Gem itself or anything, but the essential changes are done.

The main new feature (for me) is the support of WebSockets, which seems to be the only available method for realtime communication, because long-polling blocks the execution of tests (page not completely loaded...).
